### PR TITLE
Added offset to criteria config

### DIFF
--- a/elementapi/controllers/ElementApiController.php
+++ b/elementapi/controllers/ElementApiController.php
@@ -101,10 +101,10 @@ class ElementApiController extends BaseController
 		{
 			// Create the paginator
 			require $pluginPath.'ElementApi_PaginatorAdapter.php';
-			$paginator = new ElementApi_PaginatorAdapter($config['elementsPerPage'], $criteria->total(), $config['pageParam']);
+			$paginator = new ElementApi_PaginatorAdapter($config['elementsPerPage'], $criteria->total() - $criteria->offset, $config['pageParam']);
 
 			// Fetch this page's elements
-			$criteria->offset = $config['elementsPerPage'] * ($paginator->getCurrentPage() - 1);
+			$criteria->offset += $config['elementsPerPage'] * ($paginator->getCurrentPage() - 1);
 			$criteria->limit = $config['elementsPerPage'];
 			$elements = $criteria->find();
 			$paginator->setCount(count($elements));


### PR DESCRIPTION
Instead of just overwriting the offset criteria from the config with
the current page offset, the config offset should be added to the page offset and also change the total results number (for correct pagination).

I needed this for a infinite scroll to load entries via ajax (because X entries were already preloaded in the twig template). It could come in handy for some folks and should work with existing implementations. ;)
