### PR TITLE
Use Controller `returnJson` method for sending responses

### DIFF
--- a/elementapi/controllers/ElementApiController.php
+++ b/elementapi/controllers/ElementApiController.php
@@ -117,8 +117,6 @@ class ElementApiController extends BaseController
 			$resource = new Collection($criteria, $transformer);
 		}
 
-		JsonHelper::sendJsonHeaders();
-
 		$data = $fractal->createData($resource);
 
 		// Fire an 'onBeforeSendData' event
@@ -126,10 +124,7 @@ class ElementApiController extends BaseController
 			'data' => $data,
 		]));
 
-		echo $data->toJson();
-
-		// End the request
-		craft()->end();
+		$this->returnJson($data->toArray());
 	}
 
 	/**


### PR DESCRIPTION
I've been using the native `BaseController::returnJson` method for a couple of controllers (in another plugin), and thought they might be suited for ElementAPI, as well…

The few calls that this replaces do (almost) exactly the same thing as the `returnJson` method, except that the `onBeforeSendData` event occurred between sending headers and the response  body.

Does this disrupt plans to add additional events, or can we allow the functionality to be consolidated into `BaseController`?

:deciduous_tree:
