### PR TITLE
Readme: Add Craft namespace to string declaration of transformer class

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The [transformer](http://fractal.thephpleague.com/transformers/) that should be 
 },
 
 // Or a string/array that defines a Transformer class configuration
-'transformer' => 'MyTransformerClassName',
+'transformer' => 'Craft\MyTransformerClassName',
 
 // Or a Transformer class instance
 'transformer' => new MyTransformerClassName(),


### PR DESCRIPTION
This appears to be necessary— `call_user_func_array` (in Yii's core, which `Craft::createComponent` proxies?) won’t respect the current namespace, which is a frustrating behavior.

I hit this when trying to use the string declaration—as opposed to `new MyTransfomerClassName`, which works as expected!

[Internally](https://github.com/pixelandtonic/ElementAPI/blob/master/elementapi/controllers/ElementApiController.php#L46), it looks as though this is the way the default transformer is declared.

:deciduous_tree: 
