### PR TITLE
Enable caching of element queries

### DIFF
--- a/elementapi/config.php
+++ b/elementapi/config.php
@@ -3,4 +3,6 @@
 return [
 	'defaults' => [],
 	'endpoints' => [],
+	'cache' => false,
+	'cacheDuration' => 60,
 ];

--- a/elementapi/controllers/ElementApiController.php
+++ b/elementapi/controllers/ElementApiController.php
@@ -108,7 +108,7 @@ class ElementApiController extends BaseController
 			$criteria->offset = $config['elementsPerPage'] * ($paginator->getCurrentPage() - 1);
 			$criteria->limit = $config['elementsPerPage'];
 
-			$elements = $criteria->find();
+			$elements = craft()->elementApi->executeElementQuery($criteria);
 
 			$paginator->setCount(count($elements));
 

--- a/elementapi/controllers/ElementApiController.php
+++ b/elementapi/controllers/ElementApiController.php
@@ -108,6 +108,8 @@ class ElementApiController extends BaseController
 			$criteria->offset = $config['elementsPerPage'] * ($paginator->getCurrentPage() - 1);
 			$criteria->limit = $config['elementsPerPage'];
 
+			$elements = $criteria->find();
+
 			$paginator->setCount(count($elements));
 
 			$resource = new Collection($elements, $transformer);

--- a/elementapi/services/ElementApiService.php
+++ b/elementapi/services/ElementApiService.php
@@ -9,6 +9,100 @@ class ElementApiService extends BaseApplicationComponent
 	// Public Methods
 	// =========================================================================
 
+	/**
+	 * Executor for single-element queries. Will attempt to retrieve via the
+	 * cache, if enabled, in the config.
+	 *
+	 * @param ElementCriteriaModel $criteria
+	 *
+	 * @return mixed
+	 */
+	public function executeSingleElementQuery($criteria)
+	{
+		if ($this->cacheEnabled() && ($result = $this->getCachedQuery($criteria)))
+		{
+			return $result;
+		}
+		else
+		{
+			$element = $criteria->first();
+			$this->setCachedQuery($criteria, $element);
+			return $element;
+		}
+	}
+
+	/**
+	 * Executor for other element queries. Will attempt to retrieve via the
+	 * cache, if enabled, in the config.
+	 *
+	 * @param ElementCriteriaModel $criteria
+	 *
+	 * @return mixed
+	 */
+	public function executeElementQuery($criteria)
+	{
+		if ($this->cacheEnabled() && ($results = $this->getCachedQuery($criteria)))
+		{
+			return $results;
+		}
+		else
+		{
+			$elements = $criteria->find();
+			$this->setCachedQuery($criteria, $elements);
+			return $elements;
+		}
+	}
+
+	/**
+	 * Tries the cache for the given criteria and returns them, if the key exists.
+	 *
+	 * @param ElementCriteriaModel $criteria
+	 *
+	 * @return mixed
+	 */
+	public function getCachedQuery($criteria)
+	{
+		return craft()->cache->get($this->getCacheId($criteria->getAttributes()));
+	}
+
+	/**
+	 * Save the results of an ElementAPI query to the cache.
+	 *
+	 * @param ElementCriteriaModel $criteria
+	 * @param mixed $data
+	 * @param Integer $duration
+	 *
+	 * @return mixed
+	 */
+	public function setCachedQuery($criteria, $data)
+	{
+		return craft()->cache->set($this->getCacheId($criteria->getAttributes()), $data, craft()->config->get('cacheDuration', 'elementapi'));
+	}
+
+	/**
+	 * Composes a reliable string for identifying cached criteria.
+	 *
+	 * @param Array $attributes
+	 *
+	 * @return string
+	 */
+	private function getCacheId($attributes)
+	{
+		return 'elementapi_' . md5(json_encode($attributes));
+	}
+
+	/**
+	 * Shorthand way of determining whether attempts to set and get queries
+	 * from the cache are allowed.
+	 *
+	 * @return boolean
+	 */
+	private function cacheEnabled()
+	{
+		return craft()->config->get('cache', 'elementapi');
+	}
+
+
 	// Events
 	// -------------------------------------------------------------------------
 


### PR DESCRIPTION
I don't really know that this is worth a PR, but I wanted to get it in front of the team, in case there are some really obvious no-nos. I'd noticed a couple of other attempts at this, but for one reason or another, I decided to give it a go, myself…

I'm working on a project that promises to have a certain volume of traffic that could begin to impact other site features without _some_ kind of caching for JSON responses. It seemed like the right time to experiment with modifying/contributing to a Craft project!

What's been implemented:
- Two new config settings, `cache` and `cacheDuration` to enable and configure query caching. They exist outside the `defaults` array, in part because (unrelated), config files that are not multi-environment aren't merged recursively. We also needed to fetch them throughout the plugin, not just as part of the `$config` array in the primary Controller action (which is really more of a set of default criteria)
- A few new methods that proxy all element queries through some logic that determines whether to try the Craft cache before cold-fetching out of the database.
- A method to build cache keys from attributes set on an `EntryCriteriaModel`

A note on cache keys: I was experiencing an odd behavior with `ElementCriteriaModel` pre- and post-execution— the `locale` attribute was `null` _until any of the fetching methods were called_. That meant that building a lookup hash would be different than the one built from an query that had been executed. The locale had to be set prior to fetching to make sure that:
- Cache keys matched for setting and getting data
- Incoming and outgoing data was in the expected language (rather than always in the default language)

This key-building method was adopted from another plugin (which used just a single attribute), but I'm not convinced that this will comprehensively/uniquely describe all the parameters for an `EntryCriteriaModel`… Or that the language is correctly set by using `craft()->getLanguage()`. What is the typical approach in Craft for something like this? Is there any way to invalidate the cache when the underlying data changes?

Now we've got ye' old bag of worms wide open. :smile: Any help is appreciated!

:deciduous_tree:
